### PR TITLE
Accumulate markdown changelog in single file for release branch

### DIFF
--- a/.github/actions/milestone-changelog/action.yml
+++ b/.github/actions/milestone-changelog/action.yml
@@ -17,25 +17,18 @@ runs:
         echo "::set-output name=milestone_title::${{ fromJSON(inputs.milestone).title }}"
         echo "::set-output name=milestone_number::${{ fromJSON(inputs.milestone).number }}"
 
-    # The gh utility has a shortcut to filter merged PRs by milestone, while it would require
-    # multiple calls in JS rest client
-    - name: Find Merged Pull Requsts
+    # Fetch merged PRs in milestone
+    - name: Find Merged Pull Requests
       id: merged_milestone
-      shell: bash
+      uses: actions/github-script@v5
+      with:
+        result-encoding: json
+        script: |
+          const fetch = require('./.github/scripts/js/changelog-find-pulls.js')
+          const prs = await fetch({ github, context }, { milestone: process.env.MILESTONE })
+          core.setOutput("prs", prs)
       env:
-        GITHUB_TOKEN: ${{ inputs.token }}
-      # Pick at most 1000 PRs with possible changes blocks;
-      # skip auto-generated PRs
-      run: |
-        prs="$(jq -c '[.[] | select(all( .labels[]; .name != "auto" )) | del(.labels) ]' <<< "$(
-          gh pr list \
-            --repo '${{ github.repository }}' \
-            --search 'milestone:${{ steps.args.outputs.milestone_title }}' \
-            --state merged \
-            --limit 1000 \
-            --json number,url,title,body,state,milestone,labels
-          )")"
-        echo "::set-output name=prs::${prs}"
+        MILESTONE: ${{ steps.args.outputs.milestone_title }}
 
     - name: Collect Changelog
       id: changelog
@@ -44,8 +37,9 @@ runs:
         token: ${{ inputs.token }}
         pull_requests: ${{ steps.merged_milestone.outputs.prs }}
 
-    - name: Write Changelog File
-      id: file
+    ## Generate changes by section in YAML
+    - name: Write Changelog YAML
+      id: file_yaml
       shell: bash
       run: |
         mkdir -p ./CHANGELOG
@@ -53,6 +47,38 @@ runs:
         cat > "$filename" <<EOBODYINACTION
         ${{ steps.changelog.outputs.yaml }}
         EOBODYINACTION
+
+    ## Generate changelog for minor version branch in Markdown
+    - name: Write Changelog Markdown
+      id: file_md
+      shell: bash
+      run: |
+        new_changes="${{ steps.changelog.outputs.partial_markdown }}"
+
+        patch_version="${{ steps.args.outputs.milestone_title }}"
+        minor_version="$(echo "${patch_version}" | cut -d. -f1,2 | awk "{print $1$2}")"
+
+        filename="./CHANGELOG/CHANGELOG-${minor_version}.yml"
+
+        prev_changes_filename="/tmp/prev_changes.md"
+        if [[ -f "$filename" ]]; then
+          title_pattern="^# Changelog"
+          egrep -v "$title_pattern" "$filename" > "$prev_changes_filename"
+        fi
+
+        cat > "$filename" <<EOCHANGELOG
+        # Changelog ${minor_version}
+
+        ## ${patch_version}
+
+        $new_changes
+
+        EOCHANGELOG
+
+        if [[ -f "$prev_changes_filename" ]]; then
+          cat "$prev_changes_filename" >> "$filename"
+          rm "$prev_changes_filename"
+        fi
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3.10.1

--- a/.github/scripts/js/changelog-find-pulls.js
+++ b/.github/scripts/js/changelog-find-pulls.js
@@ -1,0 +1,25 @@
+//@ts-check
+
+// Gets issue in context, ensures it is PR with milestone, and returns the milestone.
+//
+// Using search API to find merged PRs in current milestone and without "auto" label
+module.exports = async function ({ github, context }, { milestone }) {
+  const repo = `${context.repo.owner}/${context.repo.repo}`;
+  const q = `repo:${repo} is:pr is:merged milestone:${milestone} -label:auto`;
+
+  const pulls = await github.paginate(github.rest.search.issuesAndPullRequests, { q });
+
+  // Make JSON compact to pass it further as string
+  return pulls.map((p) => ({
+    url: p.url,
+    number: p.number,
+    title: p.title,
+    body: p.body,
+    state: p.state,
+    milestone: {
+      number: p.milestone.number,
+      title: p.milestone.title,
+      state: p.milestone.state
+    }
+  }));
+};


### PR DESCRIPTION
- rewrite fetching of milestone pulls in JS
- concatenate partial changelogs together

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: markdown
type: feature
description: mmmmm
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
